### PR TITLE
feat: add xpath wrapping method in run

### DIFF
--- a/docx/text/run.py
+++ b/docx/text/run.py
@@ -5,7 +5,7 @@ Run-related proxy objects for python-docx, Run in particular.
 """
 
 from __future__ import absolute_import, print_function, unicode_literals, annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from ..enum.style import WD_STYLE_TYPE
 from ..enum.text import WD_BREAK
@@ -17,6 +17,7 @@ from ..fntent.endnoteReference import EndnoteReference
 
 if TYPE_CHECKING:
     from docx.oxml.text.run import CT_R
+    from docx.oxml.xmlchemy import MetaOxmlElement
 
 class Run(Parented):
     """
@@ -203,6 +204,13 @@ class Run(Parented):
         """
 
         return [EndnoteReference(endnoteReference, self) for endnoteReference in self._r.endnoteReference_lst]
+
+    def xpath(self, path: str) -> List[MetaOxmlElement]:
+        """
+        Return list of element.
+        if Element is not wrapped return `_Element` object.
+        """
+        return self._element.xpath(path)
 
 class _Text(object):
     """


### PR DESCRIPTION
add wrapped `xpath` method in `Run` for use `xpath` from `run` instance.
not call `run._element.xpath`.